### PR TITLE
Add Logarithmic Scaling Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Android Slider Preference Library
 
 ## Overview
 
-* Slider represents a `float` between `0.0` and `1.0`
+* Slider saves its value as a `float`
   * Access with `SliderPreference.getValue()` or [`SharedPreferences.getFloat()`][shar]
+  * Basic implementation has a linear scale ranging between `0.0` and `1.0`, and produces values suitable for use as addends
+  * Alternate implementation has a logarithmic scale ranging from `0.1` to `10.0`, and produces values suitable for use as multipliers
 * Supports multiple summaries (e.g. "Low", "Medium", "High") and selects one based on the slider's position
   * Java: `SliderPreference.setSummary(CharSequence[] summaries)`
   * XML: `android:summary="@array/string_array_of_summaries"`

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Android Slider Preference Library
 
 * Slider saves its value as a `float`
   * Access with `SliderPreference.getValue()` or [`SharedPreferences.getFloat()`][shar]
-  * Basic implementation has a linear scale ranging between `0.0` and `1.0`, and produces values suitable for use as addends
-  * Alternate implementation has a logarithmic scale ranging from `0.1` to `10.0`, and produces values suitable for use as multipliers
+  * Linear-scaled implementation has a default range between `0.0` and `1.0`, and produces values suitable for use as addends
+  * Logarithmic-scaled implementation has a default range between `0.1` to `10.0`, and produces values suitable for use as multipliers
+  * Range can be customized, using the `minimum` and `maximum` XML attributes
 * Supports multiple summaries (e.g. "Low", "Medium", "High") and selects one based on the slider's position
   * Java: `SliderPreference.setSummary(CharSequence[] summaries)`
   * XML: `android:summary="@array/string_array_of_summaries"`
@@ -65,11 +66,11 @@ dependencies {
     }
     ```
 
-4. Sync project, clean and build. You can use the SliderPreference as part of your project now.
+4. Sync project, clean and build. You can use a slider preference as part of your project now.
 
 ### Eclipse
 
-Before you can add a `SliderPreference` to your application, you must first add a library reference:
+Before you can add a slider preference to your application, you must first add a library reference:
 
 1. Clone or download a copy of the library
 2. Import the library into Eclipse: File menu -> Import -> Existing Project into Workspace
@@ -81,12 +82,14 @@ Before you can add a `SliderPreference` to your application, you must first add 
 
 ``` XML
 <!-- preferences.xml -->
-<net.jayschwa.android.preference.SliderPreference
+<net.jayschwa.android.preference.LinearSliderPreference xmlns:slider="http://schemas.android.com/apk/res-auto"
     android:key="my_slider"
     android:title="@string/slider_title"
     android:summary="@array/slider_summaries"
     android:defaultValue="@string/slider_default"
-    android:dialogMessage="@string/slider_message" />
+    android:dialogMessage="@string/slider_message"
+    slider:minimum="@string/slider_minimum"
+    slider:maximum="@string/slider_maximum" />
 ```
 ``` XML
 <!-- strings.xml -->
@@ -100,15 +103,19 @@ Before you can add a `SliderPreference` to your application, you must first add 
     <item>Boiling</item>  <!-- 0.75 to 1.00 -->
 </string-array>
 <item name="slider_default" format="float" type="string">0.5</item>
+<item name="slider_minimum" format="float" type="string">0.0</item>
+<item name="slider_maximum" format="float" type="string">1.0</item>
 <string name="slider_message">Optional message displayed in the dialog above the slider</string>
 ```
 
-It is possible to define the default value directly in the attribute. The summary can also be a regular string, instead of a string array:
+It is possible to define the default, maximum and minimum values directly in their respective attributes. The summary can also be a regular string, instead of a string array:
 
 ``` XML
-<net.jayschwa.android.preference.SliderPreference
+<net.jayschwa.android.preference.LinearSliderPreference xmlns:slider="http://schemas.android.com/apk/res-auto"
     android:summary="This summary is static and boring"
-    android:defaultValue="0.5" />
+    android:defaultValue="0.5"
+    slider:minimum="0.0"
+    slider:maximum="1.0" />
 ```
 
 ## Background

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -1,10 +1,10 @@
 <resources>
 
     <string name="app_name">Slider Preference Example</string>
-    <string name="slider_title">Basic Slider</string>
-    <string name="slider_message">Optional message is defined in android:dialogMessage.</string>
-
-    <item name="slider_default" format="float" type="string">0.5</item>
+    <string name="basic_slider_title">Basic Slider</string>
+    <string name="logarithmic_slider_title">Logarithmic Slider</string>
+    <string name="basic_slider_message">This preference will store a float between 0.0 and 1.0, using a linear scale.</string>
+    <string name="logarithmic_slider_message">This preference will store a float between 0.1 and 10.0, using a logarithmic scale.</string>
 
     <string-array name="slider_summaries">
         <item>Low</item>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -1,10 +1,10 @@
 <resources>
 
     <string name="app_name">Slider Preference Example</string>
-    <string name="basic_slider_title">Basic Slider</string>
+    <string name="linear_slider_title">Linear Slider</string>
     <string name="logarithmic_slider_title">Logarithmic Slider</string>
-    <string name="basic_slider_message">This preference will store a float between 0.0 and 1.0, using a linear scale.</string>
-    <string name="logarithmic_slider_message">This preference will store a float between 0.1 and 10.0, using a logarithmic scale.</string>
+    <string name="linear_slider_message">This preference will store a float between -1.0 and 5.0, using a linear scale.</string>
+    <string name="logarithmic_slider_message">This preference will store a float between 0.01 and 50.0, using a logarithmic scale.</string>
 
     <string-array name="slider_summaries">
         <item>Low</item>

--- a/example/res/xml/preferences.xml
+++ b/example/res/xml/preferences.xml
@@ -1,10 +1,17 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <net.jayschwa.android.preference.SliderPreference
-        android:defaultValue="@string/slider_default"
-        android:dialogMessage="@string/slider_message"
+        android:defaultValue="0.5"
+        android:dialogMessage="@string/basic_slider_message"
         android:key="basic_slider"
         android:summary="@array/slider_summaries"
-        android:title="@string/slider_title" />
+        android:title="@string/basic_slider_title" />
+
+    <net.jayschwa.android.preference.LogarithmicSliderPreference
+        android:defaultValue="1.0"
+        android:dialogMessage="@string/logarithmic_slider_message"
+        android:key="logarithmic_slider"
+        android:summary="@array/slider_summaries"
+        android:title="@string/logarithmic_slider_title" />
 
 </PreferenceScreen>

--- a/example/res/xml/preferences.xml
+++ b/example/res/xml/preferences.xml
@@ -1,17 +1,23 @@
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:slider="http://schemas.android.com/apk/res-auto" >
 
-    <net.jayschwa.android.preference.SliderPreference
+    <net.jayschwa.android.preference.LinearSliderPreference
         android:defaultValue="0.5"
-        android:dialogMessage="@string/basic_slider_message"
-        android:key="basic_slider"
+        android:dialogMessage="@string/linear_slider_message"
+        android:key="linear_slider"
         android:summary="@array/slider_summaries"
-        android:title="@string/basic_slider_title" />
+        android:title="@string/linear_slider_title"
+        slider:minimum="-1.0"
+        slider:maximum="5.0" />
 
     <net.jayschwa.android.preference.LogarithmicSliderPreference
         android:defaultValue="1.0"
         android:dialogMessage="@string/logarithmic_slider_message"
         android:key="logarithmic_slider"
         android:summary="@array/slider_summaries"
-        android:title="@string/logarithmic_slider_title" />
+        android:title="@string/logarithmic_slider_title"
+        slider:minimum="0.01"
+        slider:maximum="50.0" />
 
 </PreferenceScreen>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -10,4 +10,8 @@ Licensed under the MIT License (see LICENSE.txt)
         <attr name="android:summary" />
     </declare-styleable>
 
+    <declare-styleable name="LogarithmicSliderPreference">
+        <attr name="android:summary" />
+    </declare-styleable>
+
 </resources>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -6,12 +6,23 @@ Licensed under the MIT License (see LICENSE.txt)
 -->
 <resources>
 
+    <attr name="minimum" format="float" />
+    <attr name="maximum" format="float" />
+
     <declare-styleable name="SliderPreference">
         <attr name="android:summary" />
     </declare-styleable>
 
     <declare-styleable name="LogarithmicSliderPreference">
         <attr name="android:summary" />
+        <attr name="minimum" />
+        <attr name="maximum" />
+    </declare-styleable>
+
+    <declare-styleable name="LinearSliderPreference">
+        <attr name="android:summary" />
+        <attr name="minimum" />
+        <attr name="maximum" />
     </declare-styleable>
 
 </resources>

--- a/src/net/jayschwa/android/preference/LinearSliderPreference.java
+++ b/src/net/jayschwa/android/preference/LinearSliderPreference.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 Jay Weisskopf
+ *
+ * Licensed under the MIT License (see LICENSE.txt)
+ */
+
+package net.jayschwa.android.preference;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+
+/**
+ * @author Ryan Archer
+ */
+public class LinearSliderPreference extends SliderPreference {
+
+	private static final float defaultMinimum = (float) 0.0;
+	private static final float defaultMaximum = (float) 1.0;
+
+	// mapping equation is: mappedValue = a * unmappedValue + b, where a and b are constants, so:
+	private final float a;
+	private final float b;
+
+	private static float calculateA(final float minimum, final float maximum) {
+		return (maximum - minimum) / (defaultMaximum - defaultMinimum);
+	}
+
+	private static float calculateB(final float a, final float maximum) {
+		return maximum - a * defaultMaximum;
+	}
+
+	/**
+	 * @param context
+	 * @param attrs
+	 */
+	public LinearSliderPreference(Context context, AttributeSet attrs) {
+		super(context, attrs);
+
+		TypedArray attributes = context.obtainStyledAttributes(attrs, R.styleable.LinearSliderPreference);
+		final float minimum = attributes.getFloat(R.styleable.LinearSliderPreference_minimum, defaultMinimum);
+		final float maximum = attributes.getFloat(R.styleable.LinearSliderPreference_maximum, defaultMaximum);
+		attributes.recycle();
+		
+		a = calculateA(minimum, maximum);
+		b = calculateB(a, maximum);
+	}
+
+	/**
+	 * @param context
+	 * @param attrs
+	 * @param defStyle
+	 */
+	public LinearSliderPreference(Context context, AttributeSet attrs, int defStyle) {
+		super(context, attrs, defStyle);
+
+		TypedArray attributes = context.obtainStyledAttributes(attrs, R.styleable.LinearSliderPreference);
+		final float minimum = attributes.getFloat(R.styleable.LinearSliderPreference_minimum, defaultMinimum);
+		final float maximum = attributes.getFloat(R.styleable.LinearSliderPreference_maximum, defaultMaximum);
+		attributes.recycle();
+		
+		a = calculateA(minimum, maximum);
+		b = calculateB(a, maximum);
+	}
+
+	@Override
+	public float getValue() {
+		return map(super.getValue());
+	}
+
+	@Override
+	public void setValue(float value) {
+		super.setValueInternally(unmap(value));
+	}
+
+	@Override
+	protected void setPersistentValue(float value) {
+		persistFloat(map(value));
+	}
+
+	private float map(float unmapped) {
+		return a * unmapped + b;
+	}
+
+	private float unmap(float mapped) {
+		return (mapped - b) / a;
+	}
+}

--- a/src/net/jayschwa/android/preference/LinearSliderPreference.java
+++ b/src/net/jayschwa/android/preference/LinearSliderPreference.java
@@ -15,19 +15,16 @@ import android.util.AttributeSet;
  */
 public class LinearSliderPreference extends SliderPreference {
 
-	private static final float defaultMinimum = (float) 0.0;
-	private static final float defaultMaximum = (float) 1.0;
-
 	// mapping equation is: mappedValue = a * unmappedValue + b, where a and b are constants, so:
 	private final float a;
 	private final float b;
 
 	private static float calculateA(final float minimum, final float maximum) {
-		return (maximum - minimum) / (defaultMaximum - defaultMinimum);
+		return (maximum - minimum) / (SliderPreference.MAXIMUM - SliderPreference.MINIMUM);
 	}
 
 	private static float calculateB(final float a, final float maximum) {
-		return maximum - a * defaultMaximum;
+		return maximum - a * SliderPreference.MAXIMUM;
 	}
 
 	/**
@@ -38,8 +35,8 @@ public class LinearSliderPreference extends SliderPreference {
 		super(context, attrs);
 
 		TypedArray attributes = context.obtainStyledAttributes(attrs, R.styleable.LinearSliderPreference);
-		final float minimum = attributes.getFloat(R.styleable.LinearSliderPreference_minimum, defaultMinimum);
-		final float maximum = attributes.getFloat(R.styleable.LinearSliderPreference_maximum, defaultMaximum);
+		final float minimum = attributes.getFloat(R.styleable.LinearSliderPreference_minimum, SliderPreference.MINIMUM);
+		final float maximum = attributes.getFloat(R.styleable.LinearSliderPreference_maximum, SliderPreference.MAXIMUM);
 		attributes.recycle();
 		
 		a = calculateA(minimum, maximum);
@@ -55,8 +52,8 @@ public class LinearSliderPreference extends SliderPreference {
 		super(context, attrs, defStyle);
 
 		TypedArray attributes = context.obtainStyledAttributes(attrs, R.styleable.LinearSliderPreference);
-		final float minimum = attributes.getFloat(R.styleable.LinearSliderPreference_minimum, defaultMinimum);
-		final float maximum = attributes.getFloat(R.styleable.LinearSliderPreference_maximum, defaultMaximum);
+		final float minimum = attributes.getFloat(R.styleable.LinearSliderPreference_minimum, SliderPreference.MINIMUM);
+		final float maximum = attributes.getFloat(R.styleable.LinearSliderPreference_maximum, SliderPreference.MAXIMUM);
 		attributes.recycle();
 		
 		a = calculateA(minimum, maximum);

--- a/src/net/jayschwa/android/preference/LogarithmicSliderPreference.java
+++ b/src/net/jayschwa/android/preference/LogarithmicSliderPreference.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Jay Weisskopf
+ *
+ * Licensed under the MIT License (see LICENSE.txt)
+ */
+
+package net.jayschwa.android.preference;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+/**
+ * @author Ryan Archer
+ */
+public class LogarithmicSliderPreference extends SliderPreference {
+
+	private static final double logarithmicMinimum = 0.1;
+	private static final double logarithmicMaximum = 10.0;
+	private static final double linearMinimum = 0.0;
+	private static final double linearMaximum = 1.0;
+	private static final double base = 10.0;
+
+	// mapping equation is: logarithmicValue = a * base ^ (b * linearValue), where a and b are constants, so:
+	private static final double b = Math.log10(logarithmicMaximum / logarithmicMinimum) / (linearMaximum - linearMinimum);
+	private static final double a = logarithmicMaximum / Math.pow(base, (b * linearMaximum));
+
+	/**
+	 * @param context
+	 * @param attrs
+	 */
+	public LogarithmicSliderPreference(Context context, AttributeSet attrs) {
+		super(context, attrs);
+	}
+
+	/**
+	 * @param context
+	 * @param attrs
+	 * @param defStyle
+	 */
+	public LogarithmicSliderPreference(Context context, AttributeSet attrs, int defStyle) {
+		super(context, attrs, defStyle);
+	}
+
+	@Override
+	public float getValue() {
+		return toLogarithmic(super.getValue());
+	}
+
+	@Override
+	public void setValue(float value) {
+		super.setValueInternally(toLinear(value));
+	}
+
+	@Override
+	protected void setPersistentValue(float value) {
+		persistFloat(toLogarithmic(value));
+	}
+
+	private float toLogarithmic(float linear) {
+		return (float) (a * Math.pow(base, (b * linear)));
+	}
+
+	private float toLinear(float logarithmic) {
+		return (float) (Math.log10(logarithmic / a) / b);
+	}
+}

--- a/src/net/jayschwa/android/preference/LogarithmicSliderPreference.java
+++ b/src/net/jayschwa/android/preference/LogarithmicSliderPreference.java
@@ -7,6 +7,7 @@
 package net.jayschwa.android.preference;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.util.AttributeSet;
 
 /**
@@ -14,15 +15,23 @@ import android.util.AttributeSet;
  */
 public class LogarithmicSliderPreference extends SliderPreference {
 
-	private static final double logarithmicMinimum = 0.1;
-	private static final double logarithmicMaximum = 10.0;
+	private static final float defaultLogarithmicMinimum = (float) 0.1;
+	private static final float defaultLogarithmicMaximum = (float) 10.0;
 	private static final double linearMinimum = 0.0;
 	private static final double linearMaximum = 1.0;
 	private static final double base = 10.0;
 
 	// mapping equation is: logarithmicValue = a * base ^ (b * linearValue), where a and b are constants, so:
-	private static final double b = Math.log10(logarithmicMaximum / logarithmicMinimum) / (linearMaximum - linearMinimum);
-	private static final double a = logarithmicMaximum / Math.pow(base, (b * linearMaximum));
+	private final double a;
+	private final double b;
+
+	private static double calculateA(final double logarithmicMaximum, final double b) {
+		return logarithmicMaximum / Math.pow(base, (b * linearMaximum));
+	}
+
+	private static double calculateB(final double logarithmicMinimum, final double logarithmicMaximum) {
+		return Math.log10(logarithmicMaximum / logarithmicMinimum) / (linearMaximum - linearMinimum);
+	}
 
 	/**
 	 * @param context
@@ -30,6 +39,14 @@ public class LogarithmicSliderPreference extends SliderPreference {
 	 */
 	public LogarithmicSliderPreference(Context context, AttributeSet attrs) {
 		super(context, attrs);
+
+		TypedArray attributes = context.obtainStyledAttributes(attrs, R.styleable.LogarithmicSliderPreference);
+		final float logarithmicMinimum = attributes.getFloat(R.styleable.LogarithmicSliderPreference_minimum, defaultLogarithmicMinimum);
+		final float logarithmicMaximum = attributes.getFloat(R.styleable.LogarithmicSliderPreference_maximum, defaultLogarithmicMaximum);
+		attributes.recycle();
+
+		b = calculateB(logarithmicMinimum, logarithmicMaximum);
+		a = calculateA(logarithmicMaximum, b);
 	}
 
 	/**
@@ -39,6 +56,14 @@ public class LogarithmicSliderPreference extends SliderPreference {
 	 */
 	public LogarithmicSliderPreference(Context context, AttributeSet attrs, int defStyle) {
 		super(context, attrs, defStyle);
+
+		TypedArray attributes = context.obtainStyledAttributes(attrs, R.styleable.LogarithmicSliderPreference);
+		final float logarithmicMinimum = attributes.getFloat(R.styleable.LogarithmicSliderPreference_minimum, defaultLogarithmicMinimum);
+		final float logarithmicMaximum = attributes.getFloat(R.styleable.LogarithmicSliderPreference_maximum, defaultLogarithmicMaximum);
+		attributes.recycle();
+
+		b = calculateB(logarithmicMinimum, logarithmicMaximum);
+		a = calculateA(logarithmicMaximum, b);
 	}
 
 	@Override

--- a/src/net/jayschwa/android/preference/LogarithmicSliderPreference.java
+++ b/src/net/jayschwa/android/preference/LogarithmicSliderPreference.java
@@ -17,8 +17,6 @@ public class LogarithmicSliderPreference extends SliderPreference {
 
 	private static final float defaultLogarithmicMinimum = (float) 0.1;
 	private static final float defaultLogarithmicMaximum = (float) 10.0;
-	private static final double linearMinimum = 0.0;
-	private static final double linearMaximum = 1.0;
 	private static final double base = 10.0;
 
 	// mapping equation is: logarithmicValue = a * base ^ (b * linearValue), where a and b are constants, so:
@@ -26,11 +24,11 @@ public class LogarithmicSliderPreference extends SliderPreference {
 	private final double b;
 
 	private static double calculateA(final double logarithmicMaximum, final double b) {
-		return logarithmicMaximum / Math.pow(base, (b * linearMaximum));
+		return logarithmicMaximum / Math.pow(base, (b * SliderPreference.MAXIMUM));
 	}
 
 	private static double calculateB(final double logarithmicMinimum, final double logarithmicMaximum) {
-		return Math.log10(logarithmicMaximum / logarithmicMinimum) / (linearMaximum - linearMinimum);
+		return Math.log10(logarithmicMaximum / logarithmicMinimum) / (SliderPreference.MAXIMUM - SliderPreference.MINIMUM);
 	}
 
 	/**

--- a/src/net/jayschwa/android/preference/SliderPreference.java
+++ b/src/net/jayschwa/android/preference/SliderPreference.java
@@ -99,14 +99,22 @@ public class SliderPreference extends DialogPreference {
 	}
 
 	public void setValue(float value) {
+		setValueInternally(value);
+	}
+
+	protected void setValueInternally(float value) {
 		value = Math.max(0, Math.min(value, 1)); // clamp to [0, 1]
 		if (shouldPersist()) {
-			persistFloat(value);
+			setPersistentValue(value);
 		}
 		if (value != mValue) {
 			mValue = value;
 			notifyChanged();
 		}
+	}
+
+	protected void setPersistentValue(float value) {
+		persistFloat(value);
 	}
 
 	@Override
@@ -140,7 +148,7 @@ public class SliderPreference extends DialogPreference {
 	protected void onDialogClosed(boolean positiveResult) {
 		final float newValue = (float) mSeekBarValue / SEEKBAR_RESOLUTION;
 		if (positiveResult && callChangeListener(newValue)) {
-			setValue(newValue);
+			setValueInternally(newValue);
 		}
 		super.onDialogClosed(positiveResult);
 	}

--- a/src/net/jayschwa/android/preference/SliderPreference.java
+++ b/src/net/jayschwa/android/preference/SliderPreference.java
@@ -18,6 +18,8 @@ import android.widget.SeekBar;
  */
 public class SliderPreference extends DialogPreference {
 
+	protected final static float MINIMUM = (float) 0.0;
+	protected final static float MAXIMUM = (float) 1.0;
 	protected final static int SEEKBAR_RESOLUTION = 10000;
 
 	protected float mValue;
@@ -56,7 +58,7 @@ public class SliderPreference extends DialogPreference {
 
 	@Override
 	protected Object onGetDefaultValue(TypedArray a, int index) {
-		return a.getFloat(index, 0);
+		return a.getFloat(index, MINIMUM);
 	}
 
 	@Override
@@ -103,7 +105,7 @@ public class SliderPreference extends DialogPreference {
 	}
 
 	protected void setValueInternally(float value) {
-		value = Math.max(0, Math.min(value, 1)); // clamp to [0, 1]
+		value = Math.max(MINIMUM, Math.min(value, MAXIMUM)); // clamp to [0, 1]
 		if (shouldPersist()) {
 			setPersistentValue(value);
 		}


### PR DESCRIPTION
Adds a subclass of `SliderPreference` that maps its value to a logarithmic scale when it saves.

The current implementation is great for settings used an additive manner, but less so for settings used in a multiplicative manner<sup>[1](#footnote1)</sup>, as perceived effects will vary by value<sup>[2](#footnote2)</sup>. Typically, sliders avoid this by applying a logarithmic scale to their output, but no such option currently exists for the Android Slider Preference library.

This pull request adds the aforementioned functionality with the following edits:
- In `SliderPreference`, the `setValue` function has been broken into several different functions, to allow subclasses to hook persistence calls correctly.  Externally, the class functions exactly the same as it did previously, and the amount of internal change is kept as minimal as possible.
- A new class `LogarithmicSliderPreference` has been added to the package `net.jayschwa.android.preference`.  It is a subclass of `SliderPreference`, and has behavior identical to its parent, with the exception of functions that export or import slider values.  These functions contain additional logic which maps the internal linear scale to an external logarithmic one, with float values between `0.0` and `10.0`.
- Documentation has been updated to reference the new implementation.

<sub><a name="footnote1">1</a>: Volume, for example.</sub>
<sub><a name="footnote2">2</a>: One can observe this by considering `0.5` to be the default value, and calculating the effective multipliers created by high and low values.  `1.0` only doubles the default, but `0.1` decreases it by a factor of `5`.