### PR TITLE
Cleanup of Android API Settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,6 @@ android {
     compileSdkVersion 21
     buildToolsVersion "21.1.2"
 
-    defaultConfig {
-        minSdkVersion 1
-        targetSdkVersion 21
-    }
-
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'

--- a/project.properties
+++ b/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-17
+target=android-21
 android.library=true


### PR DESCRIPTION
Eclipse's insistence on having Android 17 installed was annoying, so I cleaned up the API settings a bit.

More specifically:
* Updated Eclipse's project.properties file to match the manifest.
* Removed the minimum and target API settings from the build.gradle file.  These are only needed if you want to overwrite the corresponding values in the manifest, and since they are identical to those in the manifest, they are redundant.

Changes have been tested, and seem to work without any problems.