### PR TITLE
Metadata Automation

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -10,7 +10,6 @@ Licensed under the MIT License (see LICENSE.txt)
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="1"
-        android:targetSdkVersion="21" />
+        android:minSdkVersion="1" />
 
 </manifest>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5,9 +5,7 @@ Copyright 2012 Jay Weisskopf
 Licensed under the MIT License (see LICENSE.txt)
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.jayschwa.android.preference"
-    android:versionCode="1"
-    android:versionName="1.0" >
+    package="net.jayschwa.android.preference" >
 
     <uses-sdk
         android:minSdkVersion="1" />

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ android {
 
     defaultConfig {
         targetSdkVersion eclipseProperties.getProperty('target')-'android-'
+
+        // note that this code assumes it's building the latest tag, and that all tags are present in the repository;
+        // older tags can be built by cloning only a subsection of the history
+        versionCode 'git tag'.execute(null, projectDir) .text.readLines().size()
+        versionName 'git describe --tags --always HEAD'.execute(null, projectDir).text.trim()
     }
 
     sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,7 @@ android {
 
     defaultConfig {
         targetSdkVersion eclipseProperties.getProperty('target')-'android-'
-
-        // note that this code assumes it's building the latest tag, and that all tags are present in the repository;
-        // older tags can be built by cloning only a subsection of the history
-        versionCode 'git tag'.execute(null, projectDir) .text.readLines().size()
+        versionCode 'git rev-list --count HEAD'.execute(null, projectDir).text.toInteger()
         versionName 'git describe --tags --always HEAD'.execute(null, projectDir).text.trim()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,18 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def eclipseProperties=new Properties()
+file('project.properties').withInputStream {
+    eclipseProperties.load(it)
+}
+
 android {
     compileSdkVersion 21
     buildToolsVersion "21.1.2"
+
+    defaultConfig {
+        targetSdkVersion eclipseProperties.getProperty('target')-'android-'
+    }
 
     sourceSets {
         main {


### PR DESCRIPTION
This update simplifies the build process by eliminating redundant copies of several metadata constants, replacing them instead with Gradle code that distributes their values automatically.

More specifically:
- The target SDK version now exists only in the `project.properties` file, and is read via a `Properties` object.
- The version code is set equal to the number of tags currently in the Git repository, with each tag representing a single release.
- The version name is set to the name of the most recent Git tag, with some additional descriptive text added if the current `HEAD` does not point directly to a tagged commit (it's actually just Git's `describe` command).

Changes have been tested, and seem to work without any problems.