### PR TITLE
Update for Android Plugin Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ file('project.properties').withInputStream {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         targetSdkVersion eclipseProperties.getProperty('target')-'android-'


### PR DESCRIPTION
The latest Android plugin is not compatible with the build tools version requested by the library, and Gradle will forcibly update the latter if you attempt to use the two together.  The build tools version that Gradle suggests seems to work without any problems, so please make it the official version of the library.